### PR TITLE
Improvements

### DIFF
--- a/example/datadog/main.go
+++ b/example/datadog/main.go
@@ -92,7 +92,7 @@ func main() {
 	defer span.Finish()
 
 	// Use the context with the span for database operations
-	db := dbgo.WithContext(ctx, dbConn.Instance)
+	ctx, db := dbgo.WithContext(ctx, dbConn.Instance)
 
 	// Create a user
 	user := User{Name: "John Doe"}

--- a/trace_test.go
+++ b/trace_test.go
@@ -94,7 +94,7 @@ func TestEnableTracing_WhenDisabled(t *testing.T) {
 	assert.Equal(t, db, result, "should return the same db when tracing is disabled")
 }
 
-func TestWithContext_WrapsDB(t *testing.T) {
+func TestWithContext_WrapsDBAndSetsContext(t *testing.T) {
 	mockDB, _, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer mockDB.Close()
@@ -105,6 +105,11 @@ func TestWithContext_WrapsDB(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	result := WithContext(ctx, db)
+	newCtx, result := WithContext(ctx, db)
 	assert.NotNil(t, result)
+	assert.NotNil(t, newCtx)
+
+	// Verify the DB is retrievable from the returned context
+	fromCtx := GetFromContext(newCtx)
+	assert.Same(t, result, fromCtx)
 }


### PR DESCRIPTION
- Updated README to clarify features and usage.
- Implemented GetActiveConfig to retrieve the current connection configuration.
- Added tests for GetActiveConfig functionality.
- Enhanced WithContext to store DB instance in context for easier retrieval.
- Improved transaction handling with automatic span creation for tracing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an API-breaking signature change to `WithContext` and modifies transaction execution to add conditional tracing spans, which can affect call sites and observability behavior.
> 
> **Overview**
> Adds `GetActiveConfig()` and stores the last `Config` used by `GetConnection`, clearing it on `ResetConnection` (with new tests covering zero/after-connection/reset behavior).
> 
> Changes `WithContext` to return `(context.Context, *gorm.DB)` and to also store the context-bound `*gorm.DB` for later retrieval via `GetFromContext`, updating the Datadog example and unit tests accordingly.
> 
> Enhances `WithTransaction` to optionally create a Datadog `"db.transaction"` span (service-name aware) and tag errors on failure when tracing is enabled, with new transaction tracing tests; README is expanded into an API reference reflecting these behavioral changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 524a3b96bc6926beb70b249a86d7e4255a870c5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->