### PR TITLE
feat: add validation to Config and enhance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 # Makefile for db-go
 
-# Variables
-DC := docker compose
-
 # Default target
 .PHONY: help
 help:
 	@echo "Available commands:"
+	@echo "  make build     - Build the package"
+	@echo "  make test      - Run tests"
+	@echo "  make test-v    - Run tests with verbose output"
+	@echo "  make vet       - Run go vet"
+	@echo "  make fmt       - Run gofmt (check only)"
+	@echo "  make fmt-fix   - Run gofmt and fix files"
+	@echo "  make lint      - Run vet + fmt check"
 	@echo "  make up        - Start all containers (PostgreSQL and Datadog agent)"
 	@echo "  make down      - Stop and remove all containers"
 	@echo "  make restart   - Restart all containers"
@@ -14,39 +18,80 @@ help:
 	@echo "  make ps        - Show status of containers"
 	@echo "  make pg-shell  - Connect to PostgreSQL shell"
 	@echo "  make example   - Run the datadog example"
+	@echo "  make example-usecase - Run the usecase example"
+
+# Build
+.PHONY: build
+build:
+	go mod tidy
+	go build ./...
+
+# Run tests
+.PHONY: test
+test:
+	go test ./... -count=1
+
+# Run tests (verbose)
+.PHONY: test-v
+test-v:
+	go test ./... -v -count=1
+
+# Run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+# Check formatting (no write)
+.PHONY: fmt
+fmt:
+	@test -z "$$(go fmt ./...)" || (echo "Run 'make fmt-fix' to fix formatting"; exit 1)
+
+# Fix formatting
+.PHONY: fmt-fix
+fmt-fix:
+	go fmt ./...
+
+# Lint: vet + fmt check
+.PHONY: lint
+lint: vet fmt
 
 # Start containers
 .PHONY: up
 up:
-	$(DC) up -d
+	docker compose up -d
 
 # Stop containers
 .PHONY: down
 down:
-	$(DC) down
+	docker compose down
 
 # Restart containers
 .PHONY: restart
 restart:
-	$(DC) down
-	$(DC) up -d
+	docker compose down
+	docker compose up -d
 
 # Show logs
 .PHONY: logs
 logs:
-	$(DC) logs -f
+	docker compose logs -f
 
 # Show status
 .PHONY: ps
 ps:
-	$(DC) ps
+	docker compose ps
 
 # Connect to PostgreSQL shell
 .PHONY: pg-shell
 pg-shell:
-	$(DC) exec postgres psql -U postgres -d example
+	docker compose exec postgres psql -U postgres -d example
 
 # Run the datadog example
 .PHONY: example
 example:
 	cd example/datadog && go run main.go
+
+# Run the usecase example
+.PHONY: example-usecase
+example-usecase:
+	cd example/usecase && go run main.go

--- a/config.go
+++ b/config.go
@@ -1,5 +1,7 @@
 package dbgo
 
+import "time"
+
 // Config holds the settings for the database connection and optional features.
 type Config struct {
 	// PrimaryDSN is the data source name for the primary (read-write) PostgreSQL instance. Required.
@@ -8,6 +10,18 @@ type Config struct {
 	// ReplicasDSN is the list of DSNs for read-only replicas. Queries that do not use dbresolver.Write
 	// may be executed against one of these replicas (policy: random). Leave nil or empty for no replicas.
 	ReplicasDSN []string
+
+	// MaxOpenConns sets the maximum number of open connections to the database. Nil uses the driver default.
+	MaxOpenConns *int
+
+	// MaxIdleConns sets the maximum number of connections in the idle connection pool. Nil uses the driver default.
+	MaxIdleConns *int
+
+	// ConnMaxLifetime sets the maximum amount of time a connection may be reused. Nil uses the driver default.
+	ConnMaxLifetime *time.Duration
+
+	// ConnMaxIdleTime sets the maximum amount of time a connection may be idle before being closed. Nil uses the driver default.
+	ConnMaxIdleTime *time.Duration
 
 	// EnableTracing turns on Datadog APM tracing for GORM operations when true.
 	EnableTracing bool

--- a/config.go
+++ b/config.go
@@ -1,11 +1,33 @@
 package dbgo
 
+// Config holds the settings for the database connection and optional features.
 type Config struct {
-	PrimaryDSN  string
+	// PrimaryDSN is the data source name for the primary (read-write) PostgreSQL instance. Required.
+	PrimaryDSN string
+
+	// ReplicasDSN is the list of DSNs for read-only replicas. Queries that do not use dbresolver.Write
+	// may be executed against one of these replicas (policy: random). Leave nil or empty for no replicas.
 	ReplicasDSN []string
-	// Datadog Tracing configuration
-	EnableTracing        bool
-	TracingServiceName   string
+
+	// EnableTracing turns on Datadog APM tracing for GORM operations when true.
+	EnableTracing bool
+
+	// TracingServiceName is the service name shown in Datadog. If empty, the tracer default is used.
+	// See DefaultTracingServiceName for the default used by dbgo when not set.
+	TracingServiceName string
+
+	// TracingAnalyticsRate sets the fraction of traces sent to analytics (0.0 to 1.0). Nil uses tracer default.
 	TracingAnalyticsRate *float64
-	TracingErrorCheck    func(error) bool
+
+	// TracingErrorCheck is the function used to decide if an error is reported as an error span in Datadog.
+	// If nil, the tracing plugin's default behavior is used.
+	TracingErrorCheck func(error) bool
+}
+
+// Validate checks that Config has required fields. Returns an error suitable for DBConn.Error when invalid.
+func (c Config) Validate() error {
+	if c.PrimaryDSN == "" {
+		return ErrInvalidConfig
+	}
+	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package dbgo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,6 +12,10 @@ func TestConfig_ZeroValue(t *testing.T) {
 
 	assert.Empty(t, cfg.PrimaryDSN)
 	assert.Empty(t, cfg.ReplicasDSN)
+	assert.Nil(t, cfg.MaxOpenConns)
+	assert.Nil(t, cfg.MaxIdleConns)
+	assert.Nil(t, cfg.ConnMaxLifetime)
+	assert.Nil(t, cfg.ConnMaxIdleTime)
 	assert.False(t, cfg.EnableTracing)
 	assert.Empty(t, cfg.TracingServiceName)
 	assert.Nil(t, cfg.TracingAnalyticsRate)
@@ -20,19 +25,35 @@ func TestConfig_ZeroValue(t *testing.T) {
 func TestConfig_WithFields(t *testing.T) {
 	errCheck := func(err error) bool { return err != nil }
 	rate := 0.5
+	maxOpen := 25
+	maxIdle := 10
+	maxLifetime := 5 * time.Minute
+	maxIdleTime := 3 * time.Minute
 	cfg := Config{
-		PrimaryDSN:          "host=localhost dbname=test",
-		ReplicasDSN:         []string{"host=replica1", "host=replica2"},
-		EnableTracing:       true,
-		TracingServiceName:  "my-service",
+		PrimaryDSN:           "host=localhost dbname=test",
+		ReplicasDSN:          []string{"host=replica1", "host=replica2"},
+		MaxOpenConns:         &maxOpen,
+		MaxIdleConns:         &maxIdle,
+		ConnMaxLifetime:      &maxLifetime,
+		ConnMaxIdleTime:      &maxIdleTime,
+		EnableTracing:        true,
+		TracingServiceName:   "my-service",
 		TracingAnalyticsRate: &rate,
-		TracingErrorCheck:   errCheck,
+		TracingErrorCheck:    errCheck,
 	}
 
 	assert.Equal(t, "host=localhost dbname=test", cfg.PrimaryDSN)
 	assert.Len(t, cfg.ReplicasDSN, 2)
 	assert.Equal(t, "host=replica1", cfg.ReplicasDSN[0])
 	assert.Equal(t, "host=replica2", cfg.ReplicasDSN[1])
+	assert.NotNil(t, cfg.MaxOpenConns)
+	assert.Equal(t, 25, *cfg.MaxOpenConns)
+	assert.NotNil(t, cfg.MaxIdleConns)
+	assert.Equal(t, 10, *cfg.MaxIdleConns)
+	assert.NotNil(t, cfg.ConnMaxLifetime)
+	assert.Equal(t, 5*time.Minute, *cfg.ConnMaxLifetime)
+	assert.NotNil(t, cfg.ConnMaxIdleTime)
+	assert.Equal(t, 3*time.Minute, *cfg.ConnMaxIdleTime)
 	assert.True(t, cfg.EnableTracing)
 	assert.Equal(t, "my-service", cfg.TracingServiceName)
 	assert.NotNil(t, cfg.TracingAnalyticsRate)

--- a/config_test.go
+++ b/config_test.go
@@ -39,3 +39,15 @@ func TestConfig_WithFields(t *testing.T) {
 	assert.Equal(t, 0.5, *cfg.TracingAnalyticsRate)
 	assert.NotNil(t, cfg.TracingErrorCheck)
 }
+
+func TestConfig_Validate_EmptyPrimaryDSN_ReturnsError(t *testing.T) {
+	cfg := Config{}
+	err := cfg.Validate()
+	assert.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestConfig_Validate_Valid_ReturnsNil(t *testing.T) {
+	cfg := Config{PrimaryDSN: "host=localhost dbname=test"}
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}

--- a/context.go
+++ b/context.go
@@ -35,6 +35,17 @@ func GetFromContext(ctx context.Context) *gorm.DB {
 	return nil
 }
 
+// MustGetFromContext returns the *gorm.DB from ctx, or the default singleton if not set.
+// It panics if neither the context nor the default connection has a DB (e.g. before Init or after ResetConnection).
+// Use this in layers that assume the context was already initialized with a DB by middleware or a usecase.
+func MustGetFromContext(ctx context.Context) *gorm.DB {
+	db := GetFromContext(ctx)
+	if db == nil {
+		panic("dbgo: no database connection available in context or default connection")
+	}
+	return db
+}
+
 func SetFromContext(ctx context.Context, db *gorm.DB) context.Context {
 	return context.WithValue(ctx, dbContextKey, db)
 }

--- a/context.go
+++ b/context.go
@@ -11,6 +11,14 @@ type contextKey struct{}
 
 var dbContextKey = contextKey{}
 
+// GetFromContext returns the *gorm.DB from ctx, or the default singleton if not set.
+// It can return nil when neither the context nor the default connection has a DB (e.g. before Init or after ResetConnection).
+// Callers must check for nil before use; see WithTransaction for the recommended pattern:
+//
+//	dbInstance := dbgo.GetFromContext(ctx)
+//	if dbInstance == nil {
+//	    return dbgo.ErrNoDatabase
+//	}
 func GetFromContext(ctx context.Context) *gorm.DB {
 	if db, ok := ctx.Value(dbContextKey).(*gorm.DB); ok {
 		return db
@@ -23,7 +31,7 @@ func GetFromContext(ctx context.Context) *gorm.DB {
 		return instance
 	}
 
-	logger.Error(ctx, "No GORM DB instance found in context or default connection.")
+	logger.Warn(ctx, "No GORM DB instance found in context or default connection.")
 	return nil
 }
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -113,3 +113,22 @@ func TestWithContext_WrapsDBAndSetsContext(t *testing.T) {
 	fromCtx := GetFromContext(newCtx)
 	assert.Same(t, result, fromCtx)
 }
+
+func TestStartSpan_EmptyService_UsesDefault(t *testing.T) {
+	ctx := context.Background()
+	newCtx, span := StartSpan(ctx, "test-op", "")
+	assert.NotNil(t, newCtx)
+	if span != nil {
+		span.Finish()
+	}
+	// Default service name is applied when tracer is running; span may be nil when tracer not started
+}
+
+func TestStartSpan_WithService_UsesGivenService(t *testing.T) {
+	ctx := context.Background()
+	newCtx, span := StartSpan(ctx, "test-op", "my-service")
+	assert.NotNil(t, newCtx)
+	if span != nil {
+		span.Finish()
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -39,10 +39,12 @@ func WithTransaction(ctx context.Context, fn UnitOfWork) (err error) {
 	if cfg.EnableTracing {
 		var span *tracer.Span
 		opts := []tracer.StartSpanOption{}
-		if cfg.TracingServiceName != "" {
-			opts = append(opts, tracer.ServiceName(cfg.TracingServiceName))
+		svc := cfg.TracingServiceName
+		if svc == "" {
+			svc = DefaultTracingServiceName
 		}
-		span, ctx = tracer.StartSpanFromContext(ctx, "db.transaction", opts...)
+		opts = append(opts, tracer.ServiceName(svc))
+		span, ctx = tracer.StartSpanFromContext(ctx, SpanNameTransaction, opts...)
 		defer func() {
 			if err != nil {
 				span.SetTag("error", true)


### PR DESCRIPTION
- Implemented Validate method in Config to ensure PrimaryDSN is set.
- Added unit tests for Config validation scenarios.
- Updated GetConnection to return an error when validation fails.
- Enhanced existing tests to cover new validation logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection initialization/tracing defaults and adds new failure mode (`ErrInvalidConfig`) when `PrimaryDSN` is missing, which could break misconfigured consumers. Changes are otherwise additive with expanded test coverage.
> 
> **Overview**
> Adds `Config.Validate()` (with new `ErrInvalidConfig`) and makes `GetConnection` fail fast when `PrimaryDSN` is empty, while also introducing optional connection pool tuning via `MaxOpenConns`, `MaxIdleConns`, `ConnMaxLifetime`, and `ConnMaxIdleTime` applied during connection setup.
> 
> Introduces `Ping(ctx)` for readiness/liveness checks and `MustGetFromContext(ctx)` for contexts that must have a DB, plus tweaks `GetFromContext` to log a warning instead of an error when no DB is available.
> 
> Standardizes tracing defaults by adding `DefaultTracingServiceName`/`SpanNameTransaction` and using the default service name when none is provided in both `EnableTracing` and `WithTransaction`. Updates docs, Makefile dev targets, and expands unit tests across config, connection init, ping, context, and tracing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfa91240c7aaaf4b44d2c9abfd1051a2f38dee47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->