### PR TITLE
fix: resolve 3 bugs and 3 code quality issues

### DIFF
--- a/context.go
+++ b/context.go
@@ -28,6 +28,9 @@ func GetFromContext(ctx context.Context) *gorm.DB {
 	instance := conn.Instance
 	connMu.RUnlock()
 	if instance != nil {
+		if instance.Statement != nil {
+			return instance.WithContext(ctx)
+		}
 		return instance
 	}
 
@@ -46,6 +49,8 @@ func MustGetFromContext(ctx context.Context) *gorm.DB {
 	return db
 }
 
+// SetFromContext stores the given *gorm.DB in ctx and returns the updated context.
+// Retrieve it later with GetFromContext or MustGetFromContext.
 func SetFromContext(ctx context.Context, db *gorm.DB) context.Context {
 	return context.WithValue(ctx, dbContextKey, db)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -30,7 +30,28 @@ func TestGetFromContext_FallsBackToGlobalConn(t *testing.T) {
 	connMu.Unlock()
 
 	result := GetFromContext(context.Background())
+	// globalDB has nil Statement (zero value), so WithContext is skipped and the
+	// instance is returned as-is. In production, conn.Instance always has a
+	// non-nil Statement (set by gorm.Open).
 	assert.Equal(t, globalDB, result)
+}
+
+func TestGetFromContext_SingtonFallback_PropagatesContext(t *testing.T) {
+	saveAndRestoreConn(t)
+
+	db, _ := newMockDB(t)
+	connMu.Lock()
+	conn = DBConn{Instance: db}
+	connMu.Unlock()
+
+	type testKey struct{}
+	ctx := context.WithValue(context.Background(), testKey{}, "sentinel")
+
+	result := GetFromContext(ctx)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.Statement)
+	assert.Equal(t, "sentinel", result.Statement.Context.Value(testKey{}),
+		"context passed to GetFromContext must be attached to the returned DB")
 }
 
 func TestGetFromContext_ReturnsNilWhenNothingAvailable(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -36,7 +36,7 @@ func TestGetFromContext_FallsBackToGlobalConn(t *testing.T) {
 	assert.Equal(t, globalDB, result)
 }
 
-func TestGetFromContext_SingtonFallback_PropagatesContext(t *testing.T) {
+func TestGetFromContext_SingletonFallback_PropagatesContext(t *testing.T) {
 	saveAndRestoreConn(t)
 
 	db, _ := newMockDB(t)

--- a/db.go
+++ b/db.go
@@ -76,13 +76,7 @@ func getConnection(config Config) *DBConn {
 		activeConfig = config
 		connMu.Unlock()
 
-		var err error
-		cfg := &gorm.Config{
-			PrepareStmt: true,
-		}
-
-		// Principal or Write/Source
-		db, err := gorm.Open(postgres.Open(config.PrimaryDSN), cfg)
+		db, err := gorm.Open(postgres.Open(config.PrimaryDSN), &gorm.Config{PrepareStmt: true})
 		if err != nil {
 			connMu.Lock()
 			conn.Instance, conn.Error = db, err
@@ -97,48 +91,25 @@ func getConnection(config Config) *DBConn {
 			return
 		}
 
-		if len(config.ReplicasDSN) == 0 {
-			// Apply Datadog tracing if enabled
-			if config.EnableTracing {
-				db, err = EnableTracing(db, config)
-				if err != nil {
-					// Option B: connection remains usable without tracing; caller gets both Instance and Error.
-					connMu.Lock()
-					conn.Instance, conn.Error = db, err
-					connMu.Unlock()
-					return
-				}
+		if len(config.ReplicasDSN) > 0 {
+			replicas := make([]gorm.Dialector, len(config.ReplicasDSN))
+			for i, r := range config.ReplicasDSN {
+				replicas[i] = postgres.Open(r)
 			}
-			connMu.Lock()
-			conn.Instance, conn.Error = db, err
-			connMu.Unlock()
-			return
+			if err = db.Use(dbresolver.Register(dbresolver.Config{
+				Replicas: replicas,
+				Policy:   dbresolver.RandomPolicy{},
+			})); err != nil {
+				connMu.Lock()
+				conn.Instance, conn.Error = db, err
+				connMu.Unlock()
+				return
+			}
 		}
 
-		replicas := make([]gorm.Dialector, len(config.ReplicasDSN))
-		for i, r := range config.ReplicasDSN {
-			replicas[i] = postgres.Open(r)
-		}
-
-		dbResolver := dbresolver.Config{
-			// Read Replicas
-			Replicas: replicas,
-			Policy:   dbresolver.RandomPolicy{},
-		}
-
-		err = db.Use(dbresolver.Register(dbResolver))
-		if err != nil {
-			connMu.Lock()
-			conn.Instance, conn.Error = db, err
-			connMu.Unlock()
-			return
-		}
-
-		// Apply Datadog tracing if enabled
 		if config.EnableTracing {
 			db, err = EnableTracing(db, config)
 			if err != nil {
-				// Option B: connection remains usable without tracing; caller gets both Instance and Error.
 				connMu.Lock()
 				conn.Instance, conn.Error = db, err
 				connMu.Unlock()

--- a/trace.go
+++ b/trace.go
@@ -98,7 +98,7 @@ func EnableTracing(db *gorm.DB, cfg Config) (*gorm.DB, error) {
 
 	plugin := gormtrace.NewTracePlugin(opts...)
 	if err := db.Use(plugin); err != nil {
-		return nil, err
+		return db, err
 	}
 
 	return db, nil

--- a/trace_test.go
+++ b/trace_test.go
@@ -94,6 +94,28 @@ func TestEnableTracing_WhenDisabled(t *testing.T) {
 	assert.Equal(t, db, result, "should return the same db when tracing is disabled")
 }
 
+func TestEnableTracing_WhenUsePluginFails_ReturnsOriginalDB(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: mockDB}), &gorm.Config{})
+	assert.NoError(t, err)
+
+	cfg := Config{EnableTracing: true, TracingServiceName: "test-svc"}
+
+	// First call registers the plugin successfully.
+	db, err = EnableTracing(db, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+
+	// Second call: plugin name already registered → db.Use returns an error.
+	result, err2 := EnableTracing(db, cfg)
+	assert.Error(t, err2, "expected error on duplicate plugin registration")
+	assert.NotNil(t, result, "db must not be nil even when EnableTracing fails")
+	assert.Same(t, db, result, "must return the original db, not nil")
+}
+
 func TestWithContext_WrapsDBAndSetsContext(t *testing.T) {
 	mockDB, _, err := sqlmock.New()
 	assert.NoError(t, err)

--- a/transaction.go
+++ b/transaction.go
@@ -17,6 +17,9 @@ var ErrNoDatabase = errors.New("dbgo: no database connection available")
 type UnitOfWork func(ctx context.Context) error
 
 func isTransaction(db *gorm.DB) bool {
+	if db == nil || db.Statement == nil {
+		return false
+	}
 	_, ok := db.Statement.ConnPool.(gorm.TxCommitter)
 	return ok
 }
@@ -38,13 +41,7 @@ func WithTransaction(ctx context.Context, fn UnitOfWork) (err error) {
 	cfg := GetActiveConfig()
 	if cfg.EnableTracing {
 		var span *tracer.Span
-		opts := []tracer.StartSpanOption{}
-		svc := cfg.TracingServiceName
-		if svc == "" {
-			svc = DefaultTracingServiceName
-		}
-		opts = append(opts, tracer.ServiceName(svc))
-		span, ctx = tracer.StartSpanFromContext(ctx, SpanNameTransaction, opts...)
+		ctx, span = StartSpan(ctx, SpanNameTransaction, cfg.TracingServiceName)
 		defer func() {
 			if err != nil {
 				span.SetTag("error", true)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -36,6 +36,11 @@ func TestUnitOfWork_Type(t *testing.T) {
 	assert.NoError(t, fn(context.Background()))
 }
 
+func TestIsTransaction_NilStatement(t *testing.T) {
+	// &gorm.DB{} zero-value has a nil Statement — must not panic.
+	assert.False(t, isTransaction(&gorm.DB{}))
+}
+
 func TestWithTransaction_Success(t *testing.T) {
 	saveAndRestoreConn(t)
 


### PR DESCRIPTION
Bug fixes:
- EnableTracing: return original db (not nil) when db.Use fails, so
  the connection remains usable as intended (trace.go)
- isTransaction: add nil guard for db.Statement to prevent panic on
  zero-value *gorm.DB (transaction.go)
- GetFromContext: attach ctx to singleton fallback via WithContext so
  context cancellation and deadlines propagate to queries (context.go)

Code quality:
- getConnection: remove duplicated tracing block; setup now flows
  open → pool → replicas → tracing in a single linear path (db.go)
- WithTransaction: replace inline span creation with StartSpan helper
  to avoid duplicating service-name fallback logic (transaction.go)
- SetFromContext: add missing Go doc comment (context.go)

Tests added:
- TestEnableTracing_WhenUsePluginFails_ReturnsOriginalDB
- TestIsTransaction_NilStatement
- TestGetFromContext_SingtonFallback_PropagatesContext